### PR TITLE
Fix releasing new gems to Rubygems via GitHub actions

### DIFF
--- a/.github/workflows/publish_gem.yml
+++ b/.github/workflows/publish_gem.yml
@@ -1,20 +1,28 @@
 on:
-  push:
-    branches:
-      - "main"
-    tags:
-      - v*
+  - push
+
 jobs:
   build:
     runs-on: ubuntu-latest
-
+    if: ${{ github.ref == 'refs/heads/main' }}
     steps:
-      - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
+    - uses: ruby/setup-ruby@v1
+    - name: Install dependencies
+      run: gem update --system
 
-      - name: Release Gem
-        if: contains(github.ref, 'refs/tags/v')
-        uses: cadwallion/publish-rubygems-action@master
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-          RUBYGEMS_API_KEY: ${{secrets.RUBYGEMS_API_KEY}}
-          RELEASE_COMMAND: rake release
+    - env:
+        GEM_HOST_API_KEY: ${{ secrets.RUBYGEMS_API_KEY }}
+      name: Push a new gem version to Rubygems
+      run: |
+        CURRENT_VERSION=$(rake gem_version)
+        PUBLISHED_GEM_VERSION=$(gem list --exact --remote govuk_markdown)
+
+        if [ "${PUBLISHED_GEM_VERSION}" != "govuk_markdown (${CURRENT_VERSION})" ]; then
+          gem build govuk_markdown.gemspec
+          gem push "govuk_markdown-${CURRENT_VERSION}.gem"
+        fi
+        if ! git ls-remote --tags --exit-code origin v${CURRENT_VERSION}; then
+          git tag v${CURRENT_VERSION}
+          git push --tags
+        fi

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
       with:
         ruby-version: 2.7
     - name: Install dependencies
-      run: bundle install
+      run: bundle install --jobs 4 --retry 3
     - name: Run linter
       run: bundle exec rubocop .
     - name: Run tests

--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,3 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in govuk_markdown.gemspec
 gemspec
-
-gem "rake", "~> 12.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    govuk_markdown (0.1.0)
+    govuk_markdown (0.2.0)
       activesupport
       redcarpet
 
@@ -25,7 +25,7 @@ GEM
       ast (~> 2.4.1)
     rack (2.2.3)
     rainbow (3.0.0)
-    rake (12.3.3)
+    rake (13.0.1)
     redcarpet (3.5.0)
     regexp_parser (1.8.2)
     rexml (3.2.4)
@@ -79,7 +79,7 @@ PLATFORMS
 
 DEPENDENCIES
   govuk_markdown!
-  rake (~> 12.0)
+  rake (~> 13.0)
   rspec
   rubocop-govuk
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ You can regenerate the example HTML file from Markdown using:
 bundle exec rake generate_example
 ```
 
+## Release a new version
+
+Update the version in [lib/govuk_markdown/version.rb](lib/govuk_markdown/version.rb) and merge to main. This will automatically release a new version using GitHub actions.
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/DfE-digital/govuk_markdown.

--- a/Rakefile
+++ b/Rakefile
@@ -1,13 +1,19 @@
 require "bundler/gem_tasks"
 task default: :spec
 
-require_relative "lib/govuk_markdown"
-
 desc "Regenerate the example HTML in example/example.html"
 task :generate_example do
+  require_relative "lib/govuk_markdown"
+
   markdown = File.read("example/example.md")
   html = GovukMarkdown.render(markdown)
 
   File.write("example/example.html", ERB.new(File.read("example/example_layout.html.erb")).result(binding))
   sh "open example/example.html"
+end
+
+task :gem_version do
+  require_relative "lib/govuk_markdown/version"
+
+  puts GovukMarkdown::VERSION
 end

--- a/Rakefile
+++ b/Rakefile
@@ -12,6 +12,7 @@ task :generate_example do
   sh "open example/example.html"
 end
 
+desc "Print the current version of the gem"
 task :gem_version do
   require_relative "lib/govuk_markdown/version"
 

--- a/lib/govuk_markdown.rb
+++ b/lib/govuk_markdown.rb
@@ -1,8 +1,8 @@
 require "active_support/all"
 require "redcarpet"
 
-require "govuk_markdown/version"
-require "govuk_markdown/renderer"
+require_relative "./govuk_markdown/version"
+require_relative "./govuk_markdown/renderer"
 
 module GovukMarkdown
   def self.render(markdown)

--- a/lib/govuk_markdown/version.rb
+++ b/lib/govuk_markdown/version.rb
@@ -1,3 +1,3 @@
 module GovukMarkdown
-  VERSION = "0.1.0".freeze
+  VERSION = "0.2.0".freeze
 end


### PR DESCRIPTION
This is the result of a frustratingly long series of commits:

https://github.com/DFE-Digital/govuk_markdown/actions