### PR TITLE
Add rendering of tables

### DIFF
--- a/lib/govuk_markdown.rb
+++ b/lib/govuk_markdown.rb
@@ -7,6 +7,6 @@ require_relative "./govuk_markdown/renderer"
 module GovukMarkdown
   def self.render(markdown)
     renderer = GovukMarkdown::Renderer.new(with_toc_data: true)
-    Redcarpet::Markdown.new(renderer).render(markdown).strip
+    Redcarpet::Markdown.new(renderer, tables: true).render(markdown).strip
   end
 end

--- a/lib/govuk_markdown/renderer.rb
+++ b/lib/govuk_markdown/renderer.rb
@@ -1,5 +1,34 @@
 module GovukMarkdown
   class Renderer < ::Redcarpet::Render::HTML
+    def table(header, body)
+      <<~HTML
+        <table class='govuk-table'>
+          <thead class='govuk-table__head'>
+            #{header}
+          </thead>
+          <tbody class='govuk-table__body'>
+            #{body}
+          </tbody>
+        </table>
+      HTML
+    end
+
+    def table_row(content)
+      <<~HTML
+        <tr class='govuk-table__row'>
+          #{content}
+        </tr>
+      HTML
+    end
+
+    def table_cell(content, _alignment)
+      <<~HTML
+        <td class='govuk-table__cell'>
+          #{content}
+        </td>
+      HTML
+    end
+
     def header(text, header_level)
       heading_size = case header_level
                      when 1 then "xl"

--- a/spec/govuk_markdown_spec.rb
+++ b/spec/govuk_markdown_spec.rb
@@ -1,6 +1,48 @@
 require "spec_helper"
 
 RSpec.describe GovukMarkdown do
+  it "renders tables" do
+    markdown =
+      <<~MD
+        | First name   | Last name    | DOB        |
+        | ------------ | ------------ | ---------- |
+        | John         | Smith        | 01-04-1970 |
+        | Alison       | Brown        | 02-05-1970 |
+        | Adam         | Sample       | 03-06-1970 |
+      MD
+
+    expected_html = <<~HTML
+      <table class='govuk-table'>
+        <thead class='govuk-table__head'>
+          <tr class='govuk-table__row'>
+            <td class='govuk-table__cell'>First name</td>
+            <td class='govuk-table__cell'>Last name</td>
+            <td class='govuk-table__cell'>DOB</td>
+          </tr>
+        </thead>
+        <tbody class='govuk-table__body'>
+          <tr class='govuk-table__row'>
+            <td class='govuk-table__cell'>John</td>
+            <td class='govuk-table__cell'>Smith</td>
+            <td class='govuk-table__cell'>01-04-1970</td>
+          </tr>
+          <tr class='govuk-table__row'>
+            <td class='govuk-table__cell'>Alison</td>
+            <td class='govuk-table__cell'>Brown</td>
+            <td class='govuk-table__cell'>02-05-1970</td>
+          </tr>
+          <tr class='govuk-table__row'>
+            <td class='govuk-table__cell'>Adam</td>
+            <td class='govuk-table__cell'>Sample</td>
+            <td class='govuk-table__cell'>03-06-1970</td>
+          </tr>
+        </tbody>
+      </table>
+    HTML
+
+    expect_equal_ignoring_ws(render(markdown), expected_html)
+  end
+
   it "renders H1s with ids and GOV.UK classes" do
     expect(render("# My title")).to eq('<h1 id="my-title" class="govuk-heading-xl">My title</h1>')
   end
@@ -77,5 +119,9 @@ RSpec.describe GovukMarkdown do
 
   def render(content)
     GovukMarkdown.render(content)
+  end
+
+  def expect_equal_ignoring_ws(first, second)
+    expect(first.lines.map(&:strip).join("")).to eq(second.lines.map(&:strip).join(""))
   end
 end


### PR DESCRIPTION
This was taken from Apply at this commit:

https://github.com/DFE-Digital/apply-for-teacher-training/blob/be2a5e8a881318de05c7510115ecca9e7feaae70/app/lib/govuk/markdown_renderer.rb