### PR TITLE
Don't emphasise snake_cased_words

### DIFF
--- a/lib/govuk_markdown.rb
+++ b/lib/govuk_markdown.rb
@@ -7,6 +7,6 @@ require_relative "./govuk_markdown/renderer"
 module GovukMarkdown
   def self.render(markdown)
     renderer = GovukMarkdown::Renderer.new(with_toc_data: true)
-    Redcarpet::Markdown.new(renderer, tables: true).render(markdown).strip
+    Redcarpet::Markdown.new(renderer, tables: true, no_intra_emphasis: true).render(markdown).strip
   end
 end

--- a/spec/govuk_markdown_spec.rb
+++ b/spec/govuk_markdown_spec.rb
@@ -71,6 +71,10 @@ RSpec.describe GovukMarkdown do
     expect(render("abc")).to eq('<p class="govuk-body-m">abc</p>')
   end
 
+  it "renders code without emphasis" do
+    expect(render("I am a snake_cased_word")).to include("snake_cased_word")
+  end
+
   it "renders unordered lists with GOV.UK classes" do
     input = <<~MARKDOWN
       * abc def


### PR DESCRIPTION
This avoids a `snake_cased_word` being internally emphasised.