### PR TITLE
Add govuk-link class to all markdown links

### DIFF
--- a/example/example.html
+++ b/example/example.html
@@ -40,6 +40,10 @@
   <div class="govuk-width-container">
     <main class="govuk-main-wrapper" id="main-content" role="main">
       <h1 id="a-h1-title-header" class="govuk-heading-xl">A h1 title header</h1>
+<h2 id="links" class="govuk-heading-l">Links</h2>
+<p class="govuk-body-m">This is <a href="https://gov.uk" class="govuk-link">linked text</a>.</p>
+<p class="govuk-body-m">This is <a href="https://gov.uk" title="The best place to find government services and information" class="govuk-link">linked text with a title</a>.</p>
+<p class="govuk-body-m">This is a linked URL <a href="https://www.gov.uk/help" class="govuk-link">https://www.gov.uk/help</a> and this is a linked email address <a href="mailto:noreply@gov.uk" class="govuk-link">noreply@gov.uk</a>.</p>
 <h2 id="lists" class="govuk-heading-l">Lists</h2>
 <p class="govuk-body-m">This is a list:</p>
 <ul class="govuk-list govuk-list--bullet">

--- a/example/example.md
+++ b/example/example.md
@@ -1,5 +1,13 @@
 # A h1 title header
 
+## Links
+
+This is [linked text](https://gov.uk).
+
+This is [linked text with a title](https://gov.uk "The best place to find government services and information").
+
+This is a linked URL <https://www.gov.uk/help> and this is a linked email address <noreply@gov.uk>.
+
 ## Lists
 
 This is a list:

--- a/lib/govuk_markdown.rb
+++ b/lib/govuk_markdown.rb
@@ -6,7 +6,7 @@ require_relative "./govuk_markdown/renderer"
 
 module GovukMarkdown
   def self.render(markdown)
-    renderer = GovukMarkdown::Renderer.new(with_toc_data: true)
+    renderer = GovukMarkdown::Renderer.new(with_toc_data: true, link_attributes: { class: "govuk-link" })
     Redcarpet::Markdown.new(renderer, tables: true, no_intra_emphasis: true).render(markdown).strip
   end
 end

--- a/lib/govuk_markdown/renderer.rb
+++ b/lib/govuk_markdown/renderer.rb
@@ -67,11 +67,6 @@ module GovukMarkdown
       end
     end
 
-    def link(link, title, content)
-      title_attribute = title.present? ? " title=\"#{title}\"" : ""
-      %(<a href="#{link}" class="govuk-link"#{title_attribute}>#{content}</a>)
-    end
-
     def hrule
       <<~HTML
         <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">

--- a/spec/govuk_markdown_spec.rb
+++ b/spec/govuk_markdown_spec.rb
@@ -105,6 +105,18 @@ RSpec.describe GovukMarkdown do
     expect(render(input)).to eq(expected.strip)
   end
 
+  it "renders a URL in angle brackets with GOV.UK classes" do
+    expect(render("<https://www.gov.uk/help>")).to eq(
+      '<p class="govuk-body-m"><a href="https://www.gov.uk/help" class="govuk-link">https://www.gov.uk/help</a></p>',
+    )
+  end
+
+  it "renders an email address in angle brackets with GOV.UK classes" do
+    expect(render("<noreply@gov.uk>")).to eq(
+      '<p class="govuk-body-m"><a href="mailto:noreply@gov.uk" class="govuk-link">noreply@gov.uk</a></p>',
+    )
+  end
+
   it "renders links without titles with GOV.UK classes" do
     expect(render("[GOV.UK homepage](https://www.gov.uk)")).to eq(
       '<p class="govuk-body-m"><a href="https://www.gov.uk" class="govuk-link">GOV.UK homepage</a></p>',
@@ -113,7 +125,7 @@ RSpec.describe GovukMarkdown do
 
   it "renders links with titles with GOV.UK classes" do
     expect(render('[GOV.UK homepage](https://www.gov.uk "My title")')).to eq(
-      '<p class="govuk-body-m"><a href="https://www.gov.uk" class="govuk-link" title="My title">GOV.UK homepage</a></p>',
+      '<p class="govuk-body-m"><a href="https://www.gov.uk" title="My title" class="govuk-link">GOV.UK homepage</a></p>',
     )
   end
 


### PR DESCRIPTION
## Context

Currently the renderer treats links differently, depending on how they are marked up (marked down?):

* `[GOV.UK homepage](https://www.gov.uk)` gets the `govuk-link` class added
* `<https://www.gov.uk>` or `<noreply@gov.uk>` does not get this class added. If a site has not enabled the `$govuk-global-styles` value in their Sass stylesheet (the default for which is `false`), then such links will appear using the browsers default colour:

  <img width="680" alt="unstyled-link" src="https://user-images.githubusercontent.com/813383/98046561-5218a400-1e22-11eb-8148-0e16d2907021.png">

## Changes proposed in this pull request

* Rather than subclass Redcarpet’s `link` method, instead use the `link_attributes` option instead. This ensures the class is added to all links, no matter how they are written.

* Add different link types to the example