### PR TITLE
[xxx] Add support for heading size

### DIFF
--- a/lib/govuk_markdown.rb
+++ b/lib/govuk_markdown.rb
@@ -5,8 +5,8 @@ require_relative "./govuk_markdown/version"
 require_relative "./govuk_markdown/renderer"
 
 module GovukMarkdown
-  def self.render(markdown)
-    renderer = GovukMarkdown::Renderer.new(with_toc_data: true, link_attributes: { class: "govuk-link" })
+  def self.render(markdown, govuk_options = {})
+    renderer = GovukMarkdown::Renderer.new(govuk_options, { with_toc_data: true, link_attributes: { class: "govuk-link" } })
     Redcarpet::Markdown.new(renderer, tables: true, no_intra_emphasis: true).render(markdown).strip
   end
 end

--- a/lib/govuk_markdown/renderer.rb
+++ b/lib/govuk_markdown/renderer.rb
@@ -1,5 +1,10 @@
 module GovukMarkdown
   class Renderer < ::Redcarpet::Render::HTML
+    def initialize(govuk_options, options = {})
+      @headings_start_with = govuk_options[:headings_start_with]
+      super options
+    end
+
     def table(header, body)
       <<~HTML
         <table class='govuk-table'>
@@ -30,16 +35,17 @@ module GovukMarkdown
     end
 
     def header(text, header_level)
-      heading_size = case header_level
-                     when 1 then "xl"
-                     when 2 then "l"
-                     when 3 then "m"
-                     else "s" end
+      valid_header_sizes = %w[xl l m s].freeze
+
+      start_size = valid_header_sizes.include?(@headings_start_with) ? @headings_start_with : "xl"
+
+      start_size_index = valid_header_sizes.find_index(start_size)
+
+      header_size = valid_header_sizes[start_size_index + header_level - 1] || "s"
 
       id_attribute = @options[:with_toc_data] ? " id=\"#{text.parameterize}\"" : ""
-
       <<~HTML
-        <h#{header_level}#{id_attribute} class="govuk-heading-#{heading_size}">#{text}</h#{header_level}>
+        <h#{header_level}#{id_attribute} class="govuk-heading-#{header_size}">#{text}</h#{header_level}>
       HTML
     end
 

--- a/spec/govuk_options_spec.rb
+++ b/spec/govuk_options_spec.rb
@@ -1,0 +1,85 @@
+require "spec_helper"
+
+RSpec.describe GovukMarkdown do
+  describe "#render" do
+    before do
+      subject { GovukMarkdown }
+    end
+
+    describe "#headings_start_with" do
+      context "when headings_start_with l" do
+        let(:heading_size) { "l" }
+
+        it "renders an H1 with large text" do
+          expect(subject.render("# An H1 title", headings_start_with: heading_size)).to eq('<h1 id="an-h1-title" class="govuk-heading-l">An H1 title</h1>')
+        end
+
+        it "renders an H2 with medium text" do
+          expect(subject.render("## An H2 title", headings_start_with: heading_size)).to eq('<h2 id="an-h2-title" class="govuk-heading-m">An H2 title</h2>')
+        end
+
+        it "renders an H3 with small text" do
+          expect(subject.render("### An H3 title", headings_start_with: heading_size)).to eq('<h3 id="an-h3-title" class="govuk-heading-s">An H3 title</h3>')
+        end
+
+        it "renders an H4 with small text" do
+          expect(subject.render("#### An H4 title", headings_start_with: heading_size)).to eq('<h4 id="an-h4-title" class="govuk-heading-s">An H4 title</h4>')
+        end
+      end
+
+      context "when headings_start_with is not given" do
+        it "renders an H1 with xl text" do
+          expect(subject.render("# An H1 title")).to eq('<h1 id="an-h1-title" class="govuk-heading-xl">An H1 title</h1>')
+        end
+
+        it "renders an H2 with l text" do
+          expect(subject.render("## An H2 title")).to eq('<h2 id="an-h2-title" class="govuk-heading-l">An H2 title</h2>')
+        end
+
+        it "renders an H3 with m text" do
+          expect(subject.render("### An H3 title")).to eq('<h3 id="an-h3-title" class="govuk-heading-m">An H3 title</h3>')
+        end
+
+        it "renders an H4 with s text" do
+          expect(subject.render("#### An H4 title")).to eq('<h4 id="an-h4-title" class="govuk-heading-s">An H4 title</h4>')
+        end
+      end
+
+      context "when an invalid headings_start_with is given" do
+        let(:heading_size) { "dog" }
+
+        it "renders an H1 with xl text" do
+          expect(subject.render("# An H1 title", headings_start_with: heading_size)).to eq('<h1 id="an-h1-title" class="govuk-heading-xl">An H1 title</h1>')
+        end
+
+        it "renders an H2 with l text" do
+          expect(subject.render("## An H2 title", headings_start_with: heading_size)).to eq('<h2 id="an-h2-title" class="govuk-heading-l">An H2 title</h2>')
+        end
+
+        it "renders an H3 with m text" do
+          expect(subject.render("### An H3 title", headings_start_with: heading_size)).to eq('<h3 id="an-h3-title" class="govuk-heading-m">An H3 title</h3>')
+        end
+
+        it "renders an H4 with s text" do
+          expect(subject.render("#### An H4 title", headings_start_with: heading_size)).to eq('<h4 id="an-h4-title" class="govuk-heading-s">An H4 title</h4>')
+        end
+      end
+
+      context "as a hash" do
+        let(:heading_size) { "m" }
+
+        it "renders an H1 with m text" do
+          expect(subject.render("# H1", { headings_start_with: heading_size })).to eq('<h1 id="h1" class="govuk-heading-m">H1</h1>')
+        end
+      end
+
+      context "when headings_start_with is nil" do
+        let(:heading_size) { nil }
+
+        it "renders an H1 with m text" do
+          expect(subject.render("# H1", { headings_start_with: heading_size })).to eq('<h1 id="h1" class="govuk-heading-xl">H1</h1>')
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
[xxx] Add support for heading size

* Add govuk_options hash to initialize on GovukMarkdown::Renderer
* Add headings_start_with as a configurable govuk_option
* This is similar implementation to the node version