### PR TITLE
Add a preprocessor step for inset text

### DIFF
--- a/lib/govuk_markdown.rb
+++ b/lib/govuk_markdown.rb
@@ -2,6 +2,7 @@ require "active_support/all"
 require "redcarpet"
 
 require_relative "./govuk_markdown/version"
+require_relative "./govuk_markdown/preprocessor"
 require_relative "./govuk_markdown/renderer"
 
 module GovukMarkdown

--- a/lib/govuk_markdown/preprocessor.rb
+++ b/lib/govuk_markdown/preprocessor.rb
@@ -7,13 +7,23 @@ module GovukMarkdown
     end
 
     def inject_inset_text
-      document.gsub(%r(\{inset-text\}(.*)\{/inset-text\})m) do
+      document.gsub(build_regexp("inset-text")) do
         <<~HTML
           <div class="govuk-inset-text">
             #{Regexp.last_match(1)}
           </div>
         HTML
       end
+    end
+
+  private
+
+    def build_regexp(tag_name, pre_tag: "{", post_tag: "}", closing: "/")
+      before  = pre_tag +           tag_name + post_tag
+      after   = pre_tag + closing + tag_name + post_tag
+      pattern = [Regexp.quote(before), "(.*)", Regexp.quote(after)].join
+
+      Regexp.compile(pattern, Regexp::EXTENDED | Regexp::MULTILINE)
     end
   end
 end

--- a/lib/govuk_markdown/preprocessor.rb
+++ b/lib/govuk_markdown/preprocessor.rb
@@ -1,0 +1,19 @@
+module GovukMarkdown
+  class Preprocessor
+    attr_reader :document
+
+    def initialize(document)
+      @document = document
+    end
+
+    def inject_inset_text
+      document.gsub(%r(\{inset-text\}(.*)\{/inset-text\})m) do
+        <<~HTML
+          <div class="govuk-inset-text">
+            #{Regexp.last_match(1)}
+          </div>
+        HTML
+      end
+    end
+  end
+end

--- a/lib/govuk_markdown/preprocessor.rb
+++ b/lib/govuk_markdown/preprocessor.rb
@@ -19,9 +19,9 @@ module GovukMarkdown
   private
 
     def build_regexp(tag_name, pre_tag: "{", post_tag: "}", closing: "/")
-      before  = pre_tag +           tag_name + post_tag
-      after   = pre_tag + closing + tag_name + post_tag
-      pattern = [Regexp.quote(before), "(.*?)", Regexp.quote(after)].join
+      start_tag = pre_tag + tag_name + post_tag
+      end_tag = pre_tag + closing + tag_name + post_tag
+      pattern = [Regexp.quote(start_tag), "(.*?)", Regexp.quote(end_tag)].join
 
       Regexp.compile(pattern, Regexp::EXTENDED | Regexp::MULTILINE)
     end

--- a/lib/govuk_markdown/preprocessor.rb
+++ b/lib/govuk_markdown/preprocessor.rb
@@ -21,7 +21,7 @@ module GovukMarkdown
     def build_regexp(tag_name, pre_tag: "{", post_tag: "}", closing: "/")
       before  = pre_tag +           tag_name + post_tag
       after   = pre_tag + closing + tag_name + post_tag
-      pattern = [Regexp.quote(before), "(.*)", Regexp.quote(after)].join
+      pattern = [Regexp.quote(before), "(.*?)", Regexp.quote(after)].join
 
       Regexp.compile(pattern, Regexp::EXTENDED | Regexp::MULTILINE)
     end

--- a/lib/govuk_markdown/renderer.rb
+++ b/lib/govuk_markdown/renderer.rb
@@ -79,5 +79,9 @@ module GovukMarkdown
         <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
       HTML
     end
+
+    def preprocess(document)
+      Preprocessor.new(document).inject_inset_text
+    end
   end
 end

--- a/spec/govuk_markdown_spec.rb
+++ b/spec/govuk_markdown_spec.rb
@@ -132,12 +132,4 @@ RSpec.describe GovukMarkdown do
   it "renders hrules with GOV.UK classes" do
     expect(render("---")).to eq('<hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">')
   end
-
-  def render(content)
-    GovukMarkdown.render(content)
-  end
-
-  def expect_equal_ignoring_ws(first, second)
-    expect(first.lines.map(&:strip).join("")).to eq(second.lines.map(&:strip).join(""))
-  end
 end

--- a/spec/preprocessor_spec.rb
+++ b/spec/preprocessor_spec.rb
@@ -1,0 +1,45 @@
+require "spec_helper"
+
+RSpec.describe "GovukMarkdown with textual component extensions" do
+  it "renders inset text within a GOV.UK classes" do
+    sample_sentence = "Lorem ipsum dolor sit amet"
+    sample_lines = <<~LINES
+      Lorem
+      ipsum
+      dolor
+      sit
+      amet
+    LINES
+
+    examples = {
+      sample_sentence => "{inset-text}#{sample_sentence}{/inset-text}",
+      sample_lines => <<~MULTILINE_EXAMPLE,
+        {inset-text}
+          #{sample_lines}
+        {/inset-text}
+      MULTILINE_EXAMPLE
+    }
+
+    examples.each do |text, markdown|
+      expected_html = <<~HTML
+        <p class="govuk-body-m">an unrelated paragraph</p>
+
+        <div class="govuk-inset-text">
+          #{text}
+        </div>
+
+        <p class="govuk-body-m">an unrelated paragraph</p>
+      HTML
+
+      markdown = <<~MD
+        an unrelated paragraph
+
+        #{markdown}
+
+        an unrelated paragraph
+      MD
+
+      expect_equal_ignoring_ws(render(markdown), expected_html)
+    end
+  end
+end

--- a/spec/preprocessor_spec.rb
+++ b/spec/preprocessor_spec.rb
@@ -1,45 +1,123 @@
 require "spec_helper"
 
 RSpec.describe "GovukMarkdown with textual component extensions" do
-  it "renders inset text within a GOV.UK classes" do
-    sample_sentence = "Lorem ipsum dolor sit amet"
-    sample_lines = <<~LINES
-      Lorem
-      ipsum
-      dolor
-      sit
-      amet
-    LINES
+  describe "inset text" do
+    let(:a_line_of_text) { "my custom text" }
 
-    examples = {
-      sample_sentence => "{inset-text}#{sample_sentence}{/inset-text}",
-      sample_lines => <<~MULTILINE_EXAMPLE,
-        {inset-text}
-          #{sample_lines}
-        {/inset-text}
-      MULTILINE_EXAMPLE
-    }
+    let(:some_lines_of_text) do
+      <<~TEXT
+        The quick
+        brown fox
+        jumped over the
+        lazy dog
+      TEXT
+    end
 
-    examples.each do |text, markdown|
-      expected_html = <<~HTML
-        <p class="govuk-body-m">an unrelated paragraph</p>
+    context "when there is an inline piece of inset text" do
+      let(:input) do
+        <<~MD
+          an unrelated paragraph
 
-        <div class="govuk-inset-text">
-          #{text}
-        </div>
+          {inset-text}#{a_line_of_text}{/inset-text}
 
-        <p class="govuk-body-m">an unrelated paragraph</p>
-      HTML
+          an unrelated paragraph
+        MD
+      end
 
-      markdown = <<~MD
-        an unrelated paragraph
+      let(:expected_output) do
+        <<~HTML
+          <p class="govuk-body-m">an unrelated paragraph</p>
 
-        #{markdown}
+          <div class="govuk-inset-text">
+            #{a_line_of_text}
+          </div>
 
-        an unrelated paragraph
-      MD
+          <p class="govuk-body-m">an unrelated paragraph</p>
+        HTML
+      end
 
-      expect_equal_ignoring_ws(render(markdown), expected_html)
+      it "renders the line of inset text" do
+        expect_equal_ignoring_ws(render(input), expected_output)
+      end
+    end
+
+    context "when there is a block of inset text" do
+      let(:some_lines_of_text) do
+        <<~TEXT
+          The quick
+          brown fox
+          jumped over the
+          lazy dog
+        TEXT
+      end
+
+      let(:input) do
+        <<~MD
+          an unrelated paragraph
+
+          {inset-text}
+            #{some_lines_of_text}
+          {/inset-text}
+
+          an unrelated paragraph
+        MD
+      end
+
+      let(:expected_output) do
+        <<~HTML
+          <p class="govuk-body-m">an unrelated paragraph</p>
+
+          <div class="govuk-inset-text">
+            #{some_lines_of_text}
+          </div>
+
+          <p class="govuk-body-m">an unrelated paragraph</p>
+        HTML
+      end
+
+      it "renders the block of inset text" do
+        expect_equal_ignoring_ws(render(input), expected_output)
+      end
+    end
+
+    context "when there are multiple blocks of inset text" do
+      let(:input) do
+        <<~MD
+          an unrelated paragraph
+
+          {inset-text}#{a_line_of_text}{/inset-text}
+
+          an unrelated paragraph
+
+          {inset-text}
+            #{some_lines_of_text}
+          {/inset-text}
+
+          an unrelated paragraph
+        MD
+      end
+
+      let(:expected_output) do
+        <<~HTML
+          <p class="govuk-body-m">an unrelated paragraph</p>
+
+          <div class="govuk-inset-text">
+            #{a_line_of_text}
+          </div>
+
+          <p class="govuk-body-m">an unrelated paragraph</p>
+
+          <div class="govuk-inset-text">
+            #{some_lines_of_text}
+          </div>
+
+          <p class="govuk-body-m">an unrelated paragraph</p>
+        HTML
+      end
+
+      it "renders both pieces of inset text separately" do
+        expect_equal_ignoring_ws(render(input), expected_output)
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,1 +1,9 @@
 require_relative "./../lib/govuk_markdown"
+
+def render(content)
+  GovukMarkdown.render(content)
+end
+
+def expect_equal_ignoring_ws(first, second)
+  expect(first.lines.map(&:strip).join("")).to eq(second.lines.map(&:strip).join(""))
+end


### PR DESCRIPTION
Add a preprocess step that injects the GOV.UK inset text component into a document when the corresponding markup is detected.

Redcarpet offers a [preprocess step](https://github.com/vmg/redcarpet#prepost-process) that allows us to transform the document either before or after the Markdown rendering. As HTML is valid markdown, it's safe to generate and inject the HTML before the regular Redcarpet rendering takes place.

The implementation here covers [inset text](https://design-system.service.gov.uk/components/inset-text/) but should work for styles like [warning text](https://design-system.service.gov.uk/components/warning-text/) or [tag](https://design-system.service.gov.uk/components/tag/).

The suggested markup here is:

```
{inset-text}Text to be inset goes here{/inset-text}
```

Alternatively, to split across multiple lines:

```
{inset-text}
  Text to be
  inset goes
  here
{/inset-text}
```
