### PR TITLE
Add details text tag rendering in preprocessor 

### DIFF
--- a/lib/govuk_markdown/preprocessor.rb
+++ b/lib/govuk_markdown/preprocessor.rb
@@ -19,15 +19,17 @@ module GovukMarkdown
 
     def inject_details
       output.gsub!(build_regexp("details")) do
+        summary, details = *construct_details_from(Regexp.last_match(1))
+
         <<~HTML
           <details class="govuk-details" data-module="govuk-details">
             <summary class="govuk-details__summary">
               <span class="govuk-details__summary-text">
-              #{Regexp.last_match(1).split('.', 2).first}
+              #{summary}
               </span>
             </summary>
             <div class="govuk-details__text">
-              #{Regexp.last_match(1).split('.', 2).last}
+              #{details}
             </div>
           </details>
         HTML
@@ -43,6 +45,20 @@ module GovukMarkdown
       pattern = [Regexp.quote(start_tag), "(.*?)", Regexp.quote(end_tag)].join
 
       Regexp.compile(pattern, Regexp::EXTENDED | Regexp::MULTILINE)
+    end
+
+    def construct_details_from(match_string, partition_characters: %w[? .])
+      summary_text, match, details = match_string.partition(Regexp.union(*partition_characters))
+
+      summary = [summary_text, format_punctuation(match)].compact.join
+
+      [summary, details].compact.map(&:strip)
+    end
+
+    def format_punctuation(match)
+      return if match.include?(".")
+
+      match
     end
   end
 end

--- a/lib/govuk_markdown/preprocessor.rb
+++ b/lib/govuk_markdown/preprocessor.rb
@@ -1,19 +1,38 @@
 module GovukMarkdown
   class Preprocessor
-    attr_reader :document
+    attr_reader :output
 
     def initialize(document)
-      @document = document
+      @output = document
     end
 
     def inject_inset_text
-      document.gsub(build_regexp("inset-text")) do
+      output.gsub!(build_regexp("inset-text")) do
         <<~HTML
           <div class="govuk-inset-text">
             #{Regexp.last_match(1)}
           </div>
         HTML
       end
+      self
+    end
+
+    def inject_details
+      output.gsub!(build_regexp("details")) do
+        <<~HTML
+          <details class="govuk-details" data-module="govuk-details">
+            <summary class="govuk-details__summary">
+              <span class="govuk-details__summary-text">
+              #{Regexp.last_match(1).split('.', 2).first}
+              </span>
+            </summary>
+            <div class="govuk-details__text">
+              #{Regexp.last_match(1).split('.', 2).last}
+            </div>
+          </details>
+        HTML
+      end
+      self
     end
 
   private

--- a/lib/govuk_markdown/renderer.rb
+++ b/lib/govuk_markdown/renderer.rb
@@ -81,7 +81,11 @@ module GovukMarkdown
     end
 
     def preprocess(document)
-      Preprocessor.new(document).inject_inset_text
+      Preprocessor
+        .new(document)
+        .inject_inset_text
+        .inject_details
+        .output
     end
   end
 end

--- a/spec/preprocessor_spec.rb
+++ b/spec/preprocessor_spec.rb
@@ -1,18 +1,20 @@
 require "spec_helper"
 
 RSpec.describe "GovukMarkdown with textual component extensions" do
+  let(:a_line_of_text) { "My custom text. Some extra details. And a few more." }
+  let(:output_summary) { "My custom text" }
+  let(:output_details_text) { "Some extra details. And a few more." }
+  let(:additional_details_text) { "Additional details. Don't you just love more details." }
+  let(:some_lines_of_text) do
+    <<~TEXT
+      The quick
+      brown fox
+      jumped over the
+      lazy dog
+    TEXT
+  end
+
   describe "inset text" do
-    let(:a_line_of_text) { "my custom text" }
-
-    let(:some_lines_of_text) do
-      <<~TEXT
-        The quick
-        brown fox
-        jumped over the
-        lazy dog
-      TEXT
-    end
-
     context "when there is an inline piece of inset text" do
       let(:input) do
         <<~MD
@@ -42,15 +44,6 @@ RSpec.describe "GovukMarkdown with textual component extensions" do
     end
 
     context "when there is a block of inset text" do
-      let(:some_lines_of_text) do
-        <<~TEXT
-          The quick
-          brown fox
-          jumped over the
-          lazy dog
-        TEXT
-      end
-
       let(:input) do
         <<~MD
           an unrelated paragraph
@@ -116,6 +109,134 @@ RSpec.describe "GovukMarkdown with textual component extensions" do
       end
 
       it "renders both pieces of inset text separately" do
+        expect_equal_ignoring_ws(render(input), expected_output)
+      end
+    end
+  end
+
+  describe "details" do
+    context "when there is a details section" do
+      let(:input) do
+        <<~MD
+          an unrelated paragraph
+
+          {details}#{a_line_of_text}{/details}
+
+          an unrelated paragraph
+        MD
+      end
+
+      let(:expected_output) do
+        <<~HTML
+          <p class="govuk-body-m">an unrelated paragraph</p>
+
+          <details class="govuk-details" data-module="govuk-details">
+            <summary class="govuk-details__summary">
+              <span class="govuk-details__summary-text">
+                #{output_summary}
+              </span>
+            </summary>
+            <div class="govuk-details__text">
+              #{output_details_text}
+            </div>
+          </details>
+
+          <p class="govuk-body-m">an unrelated paragraph</p>
+        HTML
+      end
+
+      it "renders the details section" do
+        expect_equal_ignoring_ws(render(input), expected_output)
+      end
+    end
+
+    context "multiple details sections" do
+      let(:input) do
+        <<~MD
+          an unrelated paragraph
+
+          {details}#{a_line_of_text}{/details}
+
+          {details}#{additional_details_text}{/details}
+
+          an unrelated paragraph
+        MD
+      end
+
+      let(:expected_output) do
+        <<~HTML
+          <p class="govuk-body-m">an unrelated paragraph</p>
+
+          <details class="govuk-details" data-module="govuk-details">
+            <summary class="govuk-details__summary">
+              <span class="govuk-details__summary-text">
+                #{output_summary}
+              </span>
+            </summary>
+            <div class="govuk-details__text">
+              #{output_details_text}
+            </div>
+          </details>
+
+          <details class="govuk-details" data-module="govuk-details">
+            <summary class="govuk-details__summary">
+              <span class="govuk-details__summary-text">
+                Additional details
+              </span>
+            </summary>
+            <div class="govuk-details__text">
+              Don't you just love more details.
+            </div>
+          </details>
+
+          <p class="govuk-body-m">an unrelated paragraph</p>
+        HTML
+      end
+
+      it "renders multiple details sections" do
+        expect_equal_ignoring_ws(render(input), expected_output)
+      end
+    end
+  end
+
+  describe "multiple preprocessing steps" do
+    context "inset text and details" do
+      let(:input) do
+        <<~MD
+          an unrelated paragraph
+
+          {details}#{a_line_of_text}{/details}
+
+          {inset-text}#{a_line_of_text}{/inset-text}
+
+          an unrelated paragraph
+        MD
+      end
+
+      let(:expected_output) do
+        <<~HTML
+          <p class="govuk-body-m">an unrelated paragraph</p>
+
+          <details class="govuk-details" data-module="govuk-details">
+            <summary class="govuk-details__summary">
+              <span class="govuk-details__summary-text">
+                #{output_summary}
+              </span>
+            </summary>
+            <div class="govuk-details__text">
+              #{output_details_text}
+            </div>
+          </details>
+
+          <div class="govuk-inset-text">
+            #{a_line_of_text}
+          </div>
+
+          <p class="govuk-body-m">an unrelated paragraph</p>
+        HTML
+      end
+
+      it "renders correctly" do
         expect_equal_ignoring_ws(render(input), expected_output)
       end
     end

--- a/spec/preprocessor_spec.rb
+++ b/spec/preprocessor_spec.rb
@@ -148,6 +148,80 @@ RSpec.describe "GovukMarkdown with textual component extensions" do
       it "renders the details section" do
         expect_equal_ignoring_ws(render(input), expected_output)
       end
+
+      context "and the split is on a question mark" do
+        let(:details_with_question) { "What about this fox and dog? Good question. In the end they became cute friends." }
+
+        let(:input) do
+          <<~MD
+            an unrelated paragraph
+
+            {details}#{details_with_question}{/details}
+
+            an unrelated paragraph
+          MD
+        end
+
+        let(:expected_output) do
+          <<~HTML
+            <p class="govuk-body-m">an unrelated paragraph</p>
+
+            <details class="govuk-details" data-module="govuk-details">
+              <summary class="govuk-details__summary">
+                <span class="govuk-details__summary-text">
+                  What about this fox and dog?
+                </span>
+              </summary>
+              <div class="govuk-details__text">
+                Good question. In the end they became cute friends.
+              </div>
+            </details>
+
+            <p class="govuk-body-m">an unrelated paragraph</p>
+          HTML
+        end
+
+        it "renders the details section" do
+          expect_equal_ignoring_ws(render(input), expected_output)
+        end
+      end
+
+      context "and the text contains a question mark that comes after a fullstop" do
+        let(:details) { "Find out more. Will the fox and the dog remain friends? Or are they just too different?" }
+
+        let(:input) do
+          <<~MD
+            an unrelated paragraph
+
+            {details}#{details}{/details}
+
+            an unrelated paragraph
+          MD
+        end
+
+        let(:expected_output) do
+          <<~HTML
+            <p class="govuk-body-m">an unrelated paragraph</p>
+
+            <details class="govuk-details" data-module="govuk-details">
+              <summary class="govuk-details__summary">
+                <span class="govuk-details__summary-text">
+                  Find out more
+                </span>
+              </summary>
+              <div class="govuk-details__text">
+                Will the fox and the dog remain friends? Or are they just too different?
+              </div>
+            </details>
+
+            <p class="govuk-body-m">an unrelated paragraph</p>
+          HTML
+        end
+
+        it "renders the details section" do
+          expect_equal_ignoring_ws(render(input), expected_output)
+        end
+      end
     end
 
     context "multiple details sections" do


### PR DESCRIPTION
## Context

This is a first stab at adding a preprocessing step for the [Govuk Details component](https://design-system.service.gov.uk/components/details/)

This means that a start and end tag can be used in a markdown document i.e. `{details} some title. some text. {/details}` and the correct details component will be rendered in the HTML. 

## Changes

* Add functionality for `{details}`
* Add `def inject_details` into preprocessor
* Add `def construct_details_from(match)` to construct details array and `def format_punctuation(match)` for correct formatting
* Preprocessor methods now return `self` so that they can be chained in `def preprocess`
* Call new method in `def preprocess` so that HTML is injected before the markdown is processed by the renderer
* Rename `attr_reader :document` to `attr_reader :output` so it looks nicer when we call it in `def preprocess`

## Usage

I've built this so that the first sentence within the tag will be rendered as the details summary text. The rest of the content will then be rendered as the details text e.g.

`{details} Find out about the fox and the dog. Whilst the fox is quick and brown, the dog is lazy. {/details}`

will appear like:

<img width="527" alt="Screenshot 2023-01-04 at 11 01 01" src="https://user-images.githubusercontent.com/43522239/210541198-7b2dbe53-4fe1-4879-a77b-34b026b591af.png">
